### PR TITLE
#168495649 Add Implementation for Signup Feature

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,15 +21,19 @@
   "plugins": ["react"],
   "rules": {
     "comma-dangle": 0,
+    "consistent-return": 0,
     "global-require": 0,
     "import/no-dynamic-require": 0,
     "import/no-extraneous-dependencies": 0,
+    "jsx-a11y/label-has-associated-control": 0,
     "max-len": ["error", 80, { "ignoreComments": true }],
+    "object-curly-newline": 0,
     "react/destructuring-assignment": [
       2,
       "always",
       { "ignoreClassFields": true }
     ],
+    "react/forbid-prop-types": 0,
     "react/jsx-filename-extension": [
       "error",
       { "extensions": [".js", ".jsx"] }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1501,6 +1501,38 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
@@ -5680,8 +5712,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -6831,6 +6862,11 @@
       "requires": {
         "deep-diff": "^0.3.5"
       }
+    },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
     },
     "regenerate": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,14 @@
   },
   "homepage": "https://github.com/abdulfatai360/banka-frontend-react#readme",
   "dependencies": {
+    "axios": "^0.19.0",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-redux": "^7.1.1",
     "react-router-dom": "^5.0.1",
-    "redux": "^4.0.4"
+    "redux": "^4.0.4",
+    "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,7 +1,29 @@
-/* eslint-disable import/prefer-default-export */
-import { SET_CURRENT_PAGE } from '@Constants/actionTypes';
+import { SET_CURRENT_PAGE, SIGNUP } from '@Constants/actionTypes';
+import authService from '@Services/auth';
 
 export const setCurrentPage = (pageTitle) => ({
   type: SET_CURRENT_PAGE,
   payload: pageTitle,
 });
+
+export const signup = (user) => {
+  const action = (payload) => ({ type: SIGNUP, payload });
+
+  const signupThunk = async (dispatch) => {
+    try {
+      const { data } = await authService.signup(user);
+      localStorage.setItem('user', JSON.stringify(data.data[0]));
+      dispatch(action({ status: 'completed', user: data.data[0] }));
+    } catch (err) {
+      const {
+        response: {
+          data: { error },
+        },
+      } = err;
+
+      dispatch(action({ status: 'failed', error }));
+    }
+  };
+
+  return signupThunk;
+};

--- a/src/assets/styles/index.css
+++ b/src/assets/styles/index.css
@@ -100,6 +100,22 @@ ul {
   transition: all 0.5s cubic-bezier(0.19, 1, 0.22, 1);
 }
 
+a,
+.link-in-p {
+  text-decoration: none;
+  transition: all 0.5s cubic-bezier(0.19, 1, 0.22, 1);
+}
+
+.link-in-p {
+  color: #14213d;
+  border-bottom: 1px solid;
+}
+
+.link-in-p:hover {
+  cursor: pointer;
+  border-bottom-color: transparent;
+}
+
 @media (min-width: 768px) {
   body {
     font-size: 1.55rem;

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,11 +2,15 @@ import React from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import Header from '@Components/Header/Header';
 import Homepage from '@Components/Homepage/Homepage';
+import Signup from '@Components/Signup/Signup';
+import Profile from '@Components/Profile/Profile';
 
 const App = () => (
   <BrowserRouter>
     <Header />
     <Switch>
+      <Route path="/profile" component={Profile} />
+      <Route path="/signup" component={Signup} />
       <Route path="/" component={Homepage} />
     </Switch>
   </BrowserRouter>

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -43,7 +43,8 @@
   color: inherit;
 }
 
-.Header__nav__item a:hover {
-  color: #fca311;
+.Header__nav__item a:hover,
+.current-page-link {
+  color: #fca311 !important;
   background: rgba(0, 0, 0, 0.22);
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -14,6 +14,14 @@ class Header extends Component {
       : defaultValue;
   };
 
+  setNavLinkClass = (linkLabel) => {
+    const defaultValue = '';
+    const { props } = this;
+    return props.currentPage === linkLabel.toLowerCase()
+      ? 'current-page-link'
+      : defaultValue;
+  };
+
   render() {
     return (
       <header className="Header">
@@ -25,10 +33,14 @@ class Header extends Component {
           <nav className="Header__nav">
             <ul className="Header__nav__list">
               <li className="Header__nav__item">
-                <Link to="/login">Login</Link>
+                <Link to="/signup" className={this.setNavLinkClass('signup')}>
+                  Sign Up
+                </Link>
               </li>
               <li className="Header__nav__item">
-                <Link to="/signup">Sign Up</Link>
+                <Link to="/login" className={this.setNavLinkClass('login')}>
+                  Login
+                </Link>
               </li>
             </ul>
           </nav>
@@ -44,4 +56,7 @@ Header.propTypes = {
 
 const mapStateToProps = ({ currentPage }) => ({ currentPage });
 
-export default connect(mapStateToProps)(Header);
+export default connect(
+  mapStateToProps,
+  null
+)(Header);

--- a/src/components/Profile/Profile.jsx
+++ b/src/components/Profile/Profile.jsx
@@ -1,0 +1,34 @@
+/* eslint-disable react/jsx-one-expression-per-line */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { setCurrentPage } from '@Actions/index';
+import './Profile.css';
+
+class Profile extends Component {
+  componentDidMount() {
+    const { props } = this;
+    props.setCurrentPage('profile');
+  }
+
+  render() {
+    const { props } = this;
+    return (
+      <main className="Profile row-alt">
+        <p className="container">Welcome, {props.currentUser.firstName}</p>
+      </main>
+    );
+  }
+}
+
+Profile.propTypes = {
+  currentUser: PropTypes.object.isRequired,
+  setCurrentPage: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ({ currentUser }) => ({ currentUser });
+
+export default connect(
+  mapStateToProps,
+  { setCurrentPage }
+)(Profile);

--- a/src/components/Signup/Signup.jsx
+++ b/src/components/Signup/Signup.jsx
@@ -1,0 +1,200 @@
+/* eslint-disable react/jsx-one-expression-per-line */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { validateSignupInputs } from '@Services/validations/signup';
+import { setCurrentPage, signup } from '@Actions/index';
+import Form from '@Components/common/Form/Form';
+import FormField from '@Components/common/FormField/FormField';
+import InputLabel from '@Components/common/InputLabel/InputLabel';
+import InputElement from '@Components/common/InputElement/InputElement';
+import Button from '@Components/common/Button/Button';
+import './Signup.css';
+
+class Signup extends Component {
+  state = {
+    data: {
+      firstName: '',
+      lastName: '',
+      phone: '',
+      email: '',
+      password: '',
+      confirmPassword: '',
+    },
+    errors: {},
+  };
+
+  componentDidMount() {
+    const { props } = this;
+    props.setCurrentPage('signup');
+  }
+
+  handleChange = ({ target }) => {
+    const { data } = this.state;
+    this.setState({ data: { ...data, [target.name]: target.value } });
+  };
+
+  setInputElementClass = (inputName) => {
+    const { errors } = this.state;
+    const defaultValue = 'InputElement';
+    return errors[inputName]
+      ? `${defaultValue} InputElement--has-error`
+      : defaultValue;
+  };
+
+  setValidationErrors = (errors) => this.setState({ errors });
+
+  clearInputErrorMessage = ({ target }) => {
+    const { errors } = this.state;
+    this.setState({ errors: { ...errors, [target.name]: '' } });
+  };
+
+  setSignupError = () => {
+    const { props } = this;
+    this.setState((prevState) => ({
+      errors: { ...prevState.errors, signup: props.signupStatus.error },
+    }));
+  };
+
+  redirectUserToProfile = () => {
+    const { history } = this.props;
+    history.push('/profile');
+  };
+
+  handleSubmit = async (event) => {
+    event.preventDefault();
+    const { state, props } = this;
+
+    const validationErrors = validateSignupInputs(state.data);
+    if (validationErrors) return this.setValidationErrors(validationErrors);
+
+    await props.signup(state.data);
+    if (this.props.signupStatus.error) return this.setSignupError();
+    return this.redirectUserToProfile();
+  };
+
+  render() {
+    const { data, errors } = this.state;
+
+    return (
+      <main className="Signup row">
+        <section className="container">
+          <Form
+            className="Form Form--padded Form--centered Form--bordered"
+            error={errors.signup}
+            onSubmit={this.handleSubmit}
+          >
+            <FormField className="FormField" error={errors.firstName}>
+              <InputLabel htmlFor="firstName" label="First Name" required />
+              <InputElement
+                className={this.setInputElementClass('firstName')}
+                name="firstName"
+                placeholder="e.g. John"
+                type="text"
+                value={data.firstName}
+                onChange={this.handleChange}
+                onFocus={this.clearInputErrorMessage}
+              />
+            </FormField>
+
+            <FormField className="FormField" error={errors.lastName}>
+              <InputLabel htmlFor="lastName" label="Last Name" required />
+              <InputElement
+                className={this.setInputElementClass('lastName')}
+                name="lastName"
+                placeholder="e.g. Doe"
+                type="text"
+                value={data.lastName}
+                onChange={this.handleChange}
+                onFocus={this.clearInputErrorMessage}
+              />
+            </FormField>
+
+            <FormField className="FormField" error={errors.phone}>
+              <InputLabel htmlFor="phone" label="Phone Number" required />
+              <InputElement
+                className={this.setInputElementClass('phone')}
+                name="phone"
+                placeholder="e.g. +2348012345678"
+                type="tel"
+                value={data.phone}
+                onChange={this.handleChange}
+                onFocus={this.clearInputErrorMessage}
+              />
+            </FormField>
+
+            <FormField className="FormField" error={errors.email}>
+              <InputLabel htmlFor="email" label="Email" required />
+              <InputElement
+                className={this.setInputElementClass('email')}
+                name="email"
+                placeholder="e.g. joe@domain.com"
+                type="email"
+                value={data.email}
+                onChange={this.handleChange}
+                onFocus={this.clearInputErrorMessage}
+              />
+            </FormField>
+
+            <FormField className="FormField" error={errors.password}>
+              <InputLabel htmlFor="password" label="Password" required />
+              <InputElement
+                className={this.setInputElementClass('password')}
+                name="password"
+                placeholder="e.g. *********"
+                type="password"
+                value={data.password}
+                onChange={this.handleChange}
+                onFocus={this.clearInputErrorMessage}
+              />
+            </FormField>
+
+            <FormField className="FormField" error={errors.confirmPassword}>
+              <InputLabel
+                htmlFor="confirmPassword"
+                label="Re-enter Password"
+                required
+              />
+              <InputElement
+                className={this.setInputElementClass('confirmPassword')}
+                name="confirmPassword"
+                placeholder="e.g. *********"
+                type="password"
+                value={data.confirmPassword}
+                onChange={this.handleChange}
+                onFocus={this.clearInputErrorMessage}
+              />
+            </FormField>
+
+            <FormField className="FormField" error="">
+              <Button className="Button Button--form" label="Sign Up" />
+            </FormField>
+
+            <p>
+              Already have an account?{' '}
+              <Link to="/login" className="link-in-p">
+                Login
+              </Link>
+            </p>
+          </Form>
+        </section>
+      </main>
+    );
+  }
+}
+
+Signup.propTypes = {
+  history: PropTypes.object.isRequired,
+  signupStatus: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+    .isRequired,
+  setCurrentPage: PropTypes.func.isRequired,
+  signup: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ({ signupStatus }) => ({ signupStatus });
+
+export default connect(
+  mapStateToProps,
+  { setCurrentPage, signup }
+)(Signup);

--- a/src/components/common/Button/Button.css
+++ b/src/components/common/Button/Button.css
@@ -1,0 +1,30 @@
+.Button {
+  margin: 0;
+  display: inline-block;
+  font-weight: 500;
+  font-family: 'clarke', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  text-transform: uppercase;
+  color: #000;
+  background: #fca311;
+  cursor: pointer;
+  transition: all 0.5s cubic-bezier(0.19, 1, 0.22, 1);
+}
+
+.Button[disabled] {
+  pointer-events: none;
+  cursor: not-allowed;
+  background: #e5e5e5 !important;
+}
+
+.Button--form {
+  width: 100%;
+  margin-top: 2.2rem;
+  padding: 0.8rem 1.2rem;
+  font-size: 1.3em;
+  text-align: center;
+}
+
+.Button--form:hover {
+  background: #f09d19;
+}

--- a/src/components/common/Button/Button.jsx
+++ b/src/components/common/Button/Button.jsx
@@ -1,0 +1,36 @@
+/* eslint-disable object-curly-newline */
+import React from 'react';
+import PropTypes from 'prop-types';
+import './Button.css';
+
+const Button = ({ className, disabled, label, name, title, onClick }) => (
+  <button
+    className={className}
+    disabled={disabled}
+    id={name}
+    name={name}
+    title={title}
+    type="submit"
+    onClick={onClick}
+  >
+    {label}
+  </button>
+);
+
+Button.defaultProps = {
+  disabled: false,
+  name: '',
+  title: '',
+  onClick: () => {},
+};
+
+Button.propTypes = {
+  className: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  label: PropTypes.any.isRequired,
+  name: PropTypes.string,
+  title: PropTypes.string,
+  onClick: PropTypes.func,
+};
+
+export default Button;

--- a/src/components/common/Form/Form.css
+++ b/src/components/common/Form/Form.css
@@ -1,0 +1,27 @@
+.Form {
+  max-width: 44rem;
+  margin-bottom: 2.2rem;
+  line-height: 1.5;
+  font-size: 1em;
+}
+
+.Form--padded {
+  padding: 2.2rem;
+}
+
+.Form--centered {
+  margin: 0 auto;
+}
+
+.Form--bordered {
+  border: 1px solid;
+}
+
+.Form__error {
+  padding: 1rem;
+  border: 4px solid #dd2c00;
+  font-size: 0.95em;
+  font-weight: 400;
+  color: #fff;
+  background-color: #dd5837;
+}

--- a/src/components/common/Form/Form.jsx
+++ b/src/components/common/Form/Form.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './Form.css';
+
+const Form = ({ children, className, error, onSubmit }) => (
+  <form className={className} onSubmit={onSubmit}>
+    {error && <p className="Form__error">{error}</p>}
+    {children}
+  </form>
+);
+
+Form.defaultProps = {
+  error: '',
+};
+
+Form.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string.isRequired,
+  error: PropTypes.string,
+  onSubmit: PropTypes.func.isRequired,
+};
+
+export default Form;

--- a/src/components/common/FormField/FormField.css
+++ b/src/components/common/FormField/FormField.css
@@ -1,0 +1,9 @@
+.FormField {
+  margin-bottom: 1rem;
+}
+
+.FormField__error {
+  font-size: 0.95em;
+  color: #dd2c00;
+  font-weight: 300;
+}

--- a/src/components/common/FormField/FormField.jsx
+++ b/src/components/common/FormField/FormField.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './FormField.css';
+
+const FormField = ({ children, className, error }) => (
+  <div className={className}>
+    {children}
+    {error && <span className="FormField__error">{error}</span>}
+  </div>
+);
+
+FormField.defaultProps = {
+  className: 'FormField',
+  error: '',
+};
+
+FormField.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  error: PropTypes.string,
+};
+
+export default FormField;

--- a/src/components/common/InputElement/InputElement.css
+++ b/src/components/common/InputElement/InputElement.css
@@ -1,0 +1,27 @@
+.InputElement {
+  width: 100%;
+  padding: 0.5rem;
+  font-weight: 300;
+  background: transparent;
+  border: 1px solid #8b8787;
+}
+
+.InputElement:disabled,
+.InputElement:read-only {
+  pointer-events: none;
+  cursor: not-allowed;
+  background: #e5e5e5 !important;
+}
+
+.InputElement:focus {
+  border-color: #14213d;
+}
+
+.InputElement::placeholder {
+  font-weight: 300;
+  font-size: 1em;
+}
+
+.InputElement--has-error {
+  border-color: #dd2c00;
+}

--- a/src/components/common/InputElement/InputElement.jsx
+++ b/src/components/common/InputElement/InputElement.jsx
@@ -1,0 +1,47 @@
+/* eslint-disable object-curly-newline */
+import React from 'react';
+import PropTypes from 'prop-types';
+import './InputElement.css';
+
+const InputElement = ({
+  className,
+  disabled,
+  name,
+  placeholder,
+  type,
+  value,
+  onChange,
+  onFocus,
+}) => (
+  <input
+    className={className}
+    disabled={disabled}
+    id={name}
+    name={name}
+    placeholder={placeholder}
+    type={type}
+    value={value}
+    onChange={onChange}
+    onFocus={onFocus}
+  />
+);
+
+InputElement.defaultProps = {
+  className: 'InputElement',
+  disabled: false,
+  type: 'text',
+  onFocus: () => {},
+};
+
+InputElement.propTypes = {
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  placeholder: PropTypes.string.isRequired,
+  type: PropTypes.string,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func,
+};
+
+export default InputElement;

--- a/src/components/common/InputLabel/InputLabel.css
+++ b/src/components/common/InputLabel/InputLabel.css
@@ -1,0 +1,18 @@
+.InputLabel {
+  display: inline-block;
+  font-weight: 400;
+  font-size: 0.9em;
+  color: #384d7a;
+  text-transform: capitalize;
+}
+
+.InputLabel:hover {
+  cursor: pointer;
+}
+
+abbr[title='required'] {
+  text-decoration: none;
+  color: #dd2c00;
+  font-size: 1.3em;
+  font-weight: inherit;
+}

--- a/src/components/common/InputLabel/InputLabel.jsx
+++ b/src/components/common/InputLabel/InputLabel.jsx
@@ -1,0 +1,22 @@
+/* eslint-disable react/jsx-one-expression-per-line */
+import React from 'react';
+import PropTypes from 'prop-types';
+import './InputLabel.css';
+
+const InputLabel = ({ htmlFor, label, required }) => (
+  <label htmlFor={htmlFor} className="InputLabel">
+    {label} {required && <abbr title="required">*</abbr>}
+  </label>
+);
+
+InputLabel.defaultProps = {
+  required: false,
+};
+
+InputLabel.propTypes = {
+  htmlFor: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  required: PropTypes.bool,
+};
+
+export default InputLabel;

--- a/src/constants/actionTypes.js
+++ b/src/constants/actionTypes.js
@@ -1,2 +1,3 @@
 /* eslint-disable import/prefer-default-export */
 export const SET_CURRENT_PAGE = 'SET_CURRENT_PAGE';
+export const SIGNUP = 'SIGNUP';

--- a/src/constants/apiUrl.js
+++ b/src/constants/apiUrl.js
@@ -1,0 +1,2 @@
+export const API_DEVELOPMENT_URL = 'http://localhost:3000/api/v1';
+export const API_PRODUCTION_URL = 'https://ile-ifowopamo.herokuapp.com/api/v1';

--- a/src/reducers/currentUser.js
+++ b/src/reducers/currentUser.js
@@ -1,0 +1,12 @@
+import { SIGNUP } from '@Constants/actionTypes';
+
+export default (state = {}, action) => {
+  switch (action.type) {
+    case SIGNUP: {
+      const { status, user } = action.payload;
+      return status === 'completed' ? user : state;
+    }
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,6 +1,10 @@
 import { combineReducers } from 'redux';
 import currentPage from './currentPage';
+import currentUser from './currentUser';
+import signupStatus from './signupStatus';
 
 export default combineReducers({
   currentPage,
+  currentUser,
+  signupStatus,
 });

--- a/src/reducers/signupStatus.js
+++ b/src/reducers/signupStatus.js
@@ -1,0 +1,12 @@
+import { SIGNUP } from '@Constants/actionTypes';
+
+export default (state = '', action) => {
+  switch (action.type) {
+    case SIGNUP: {
+      const { status } = action.payload;
+      return status === 'failed' ? action.payload : status;
+    }
+    default:
+      return state;
+  }
+};

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,0 +1,14 @@
+import httpService from '@Services/http';
+import { API_DEVELOPMENT_URL } from '@Constants/apiUrl';
+
+const signup = (user) => {
+  const url = `${API_DEVELOPMENT_URL}/auth/signup`;
+  return httpService.post(url, user);
+};
+
+const login = (credentials) => {
+  const url = `${API_DEVELOPMENT_URL}/auth/login`;
+  return httpService.post(url, credentials);
+};
+
+export default { signup, login };

--- a/src/services/http.js
+++ b/src/services/http.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+export default {
+  get: axios.get,
+  post: axios.post,
+  patch: axios.patch,
+  delete: axios.delete,
+};

--- a/src/services/validations/signup.js
+++ b/src/services/validations/signup.js
@@ -1,0 +1,70 @@
+export const name = (value, label) => {
+  const errors = [];
+  const nameRegExp = /^[a-zA-Z]+(([',. -][a-zA-Z ])?[a-zA-Z]*)*$/;
+
+  if (!value) errors.push(`${label} is required`);
+  if (!nameRegExp.test(value)) errors.push(`${label} should be a valid name`);
+  if (value.length < 2) errors.push('name should be minimum of 2 characters');
+  if (value.length > 50) errors.push('name should be 50 characters or less');
+
+  return errors[0];
+};
+
+export const phone = (value) => {
+  const errors = [];
+  const phoneRegExp = /^(\+234|234)[0-9]{10}$/;
+
+  if (!value) errors.push('phone number is required');
+  if (!phoneRegExp.test(value)) {
+    errors.push('enter a valid Nigerian number, prefixed by +234 or 234');
+  }
+
+  return errors[0];
+};
+
+export const email = (value) => {
+  const errors = [];
+  const emailRegExp = /^[\w._]+@[\w]+[-.]?[\w]+\.[\w]+$/;
+
+  if (!value) errors.push('email is required');
+  if (emailRegExp.test(email)) errors.push('enter a valid email address');
+  if (value.length > 254) errors.push('email should be 254 characters or less');
+
+  return errors[0];
+};
+
+export const password = (value) => {
+  const errors = [];
+
+  if (!value) errors.push('password is required');
+  if (!/\s/.test(password)) errors.push('password should not contain spaces');
+  if (value.length < 6) errors.push('password should be 2 characters or more');
+  if (value.length > 254) {
+    errors.push('password should not be more than 254 characters');
+  }
+
+  return errors[0];
+};
+
+export const confirmPassword = (value, passwordValue) => {
+  const errors = [];
+  if (passwordValue !== value || !value) errors.push('passwords do not match');
+  return errors[0];
+};
+
+export const validateSignupInputs = (userData) => {
+  const errorMessages = {
+    firstName: name(userData.firstName, 'first name'),
+    lastName: name(userData.lastName, 'last name'),
+    phone: phone(userData.phone),
+    email: email(userData.email),
+    password: password(userData.password),
+    confirmPassword: confirmPassword(
+      userData.confirmPassword,
+      userData.password
+    ),
+  };
+
+  const error = Object.values(errorMessages).filter((err) => err);
+  return error.length ? errorMessages : null;
+};

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,8 @@
 import { createStore, applyMiddleware } from 'redux';
 import logger from 'redux-logger';
+import ReduxThunk from 'redux-thunk';
 import reducer from '../reducers';
 
-const store = createStore(reducer, applyMiddleware(logger));
+const store = createStore(reducer, applyMiddleware(ReduxThunk, logger));
 
 export default store;


### PR DESCRIPTION
#### What does this PR do?

- add the implementation for users to signup to the application

#### Description of Task proposed in this pull request?

- build the signup page component
- abstract the form elements into reusable components
- consume the API endpoint for signing up users

#### How should this be manually tested (Quality Assurance)?

- run `npm start` to spin up the development server
- enter `http://localhost:8080/signup` to navigate to the signup page

#### What are the relevant pivotal tracker stories?

- [#168495649](https://www.pivotaltracker.com/story/show/168495649)

#### Any background context you want to add (Operations Impact)?

- run `npm install` to download the project's dependencies
